### PR TITLE
Support Dynamic Module NGINX ≥ 1.9.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ Installation:
 You'll need to re-compile Nginx from source to include this module.  
 Modify your compile of Nginx by adding the following directive (modified to suit your path of course):
 
+Static module (built-in nginx binary)
+
     ./configure --add-module=/absolute/path/to/nginx-hmac-secure-link
+
+Dynamic nginx module `ngx_http_hmac_secure_link_module.so` module
+
+    ./configure --add-dynamic-module=/absolute/path/to/nginx-hmac-secure-link
+
+Build Nginx
+
     make
     make install
 

--- a/config
+++ b/config
@@ -1,4 +1,14 @@
 ngx_addon_name=ngx_http_hmac_secure_link_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_hmac_secure_link_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_hmac_secure_link_module.c"
-CORE_LIBS="$CORE_LIBS -lssl"
+
+if test -n "$ngx_module_link"; then
+	ngx_module_type=HTTP
+	ngx_module_name=ngx_http_hmac_secure_link_module
+	ngx_module_srcs="$ngx_addon_dir/ngx_http_hmac_secure_link_module.c"
+	ngx_module_libs="-lcrypto"
+
+	. auto/module
+else
+	HTTP_MODULES="$HTTP_MODULES ngx_http_hmac_secure_link_module"
+	NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_hmac_secure_link_module.c"
+	CORE_LIBS="$CORE_LIBS -lcrypto"
+fi


### PR DESCRIPTION
## Tested static and shared libraries:

```
% cd /tmp; apt-get build-dep nginx && apt-get source nginx; ls -d nginx-*

# Run before: "nginx -V" copy "configure arguments: ****" to ./configure
% ./configure … --add-dynamic-module=…/nginx-hmac-secure-link && make -j4

% ls ./objs/*hmac*.so
./objs/ngx_http_hmac_secure_link_module.so

% cp -v ./objs/ngx_http_hmac_secure_link_module.so {/usr/local,}/etc/nginx/modules/
```
## etc/nginx/nginx.conf

``` nginx
load_module modules/ngx_http_hmac_secure_link_module.so;

#user  nobody;
worker_processes  1;

#error_log  logs/error.log;
#error_log  logs/error.log  notice;
#error_log  logs/error.log  info;
…
```
#### Refs
- https://www.nginx.com/blog/dynamic-modules-nginx-1-9-11/
- https://www.nginx.com/resources/wiki/extending/converting/
- https://www.nginx.com/blog/dynamic-modules-development/
