### PR TITLE
docs: add pre-built Ubuntu/Debian package installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nginx HMAC Secure Link Module
 Description:
 ============
 
-The Nginx HMAC secure link module enhances the security and functionality of the standard secure link module.  
+The Nginx HMAC secure link module enhances the security and functionality of the standard secure link module.
 Secure token is created using secure HMAC construction with an arbitrary hash algorithm supported by OpenSSL, e.g.:
 `blake2b512`, `blake2s256`, `gost`, `md4`, `md5`, `mdc2`, `rmd160`, `sha1`, `sha224`, `sha256`,
 `sha3-224`, `sha3-256`, `sha3-384`, `sha3-512`, `sha384`, `sha512`, `sha512-224`, `sha512-256`, `shake128`, `shake256`, `sm3`.
@@ -12,10 +12,32 @@ Secure token is created using secure HMAC construction with an arbitrary hash al
 Furthermore, secure token is created as described in RFC2104, that is,
 `H(secret_key XOR opad,H(secret_key XOR ipad, message))` instead of a simple `MD5(secret_key,message, expire)`.
 
+Pre-built Packages (Ubuntu / Debian):
+=====================================
+
+Pre-built packages for this module are freely available from the GetPageSpeed repository:
+
+```bash
+# Install the repository keyring
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://extras.getpagespeed.com/deb-archive-keyring.gpg \
+  | sudo tee /etc/apt/keyrings/getpagespeed.gpg >/dev/null
+
+# Add the repository (Ubuntu example - replace 'ubuntu' and 'jammy' for your distro)
+echo "deb [signed-by=/etc/apt/keyrings/getpagespeed.gpg] https://extras.getpagespeed.com/ubuntu jammy main" \
+  | sudo tee /etc/apt/sources.list.d/getpagespeed-extras.list
+
+# Install nginx and the module
+sudo apt-get update
+sudo apt-get install nginx nginx-module-hmac-secure-link
+```
+
+The module is automatically enabled after installation. Supported distributions include Debian 12/13 and Ubuntu 20.04/22.04/24.04 (both amd64 and arm64). See [the complete setup instructions](https://apt-nginx-extras.getpagespeed.com/apt-setup/).
+
 Installation:
 =============
 
-You'll need to re-compile Nginx from source to include this module.  
+You'll need to re-compile Nginx from source to include this module.
 Modify your compile of Nginx by adding the following directive (modified to suit your path of course):
 
 Static module (built-in nginx binary)


### PR DESCRIPTION
## Summary

- Added documentation for installing pre-built packages from the GetPageSpeed APT repository
- Covers Ubuntu 20.04/22.04/24.04 and Debian 12/13 (amd64 and arm64)

## Details

Pre-built dynamic module packages are freely available, making installation much simpler for Ubuntu/Debian users who don't want to compile from source.

The module is automatically enabled after installation via symlinks in `/etc/nginx/modules-enabled/`.